### PR TITLE
Simple command line interface for parsing markdown

### DIFF
--- a/dumpling-cli/Makefile
+++ b/dumpling-cli/Makefile
@@ -1,0 +1,21 @@
+SWIFT_BUILD_FLAGS=--configuration release
+
+EXECUTABLE=$(shell swift build $(SWIFT_BUILD_FLAGS) --show-bin-path)/dumpling-cli
+BINARIES_FOLDER=/usr/local/bin
+
+.PHONY: all clean build install package test uninstall docs
+
+
+build:
+	swift build $(SWIFT_BUILD_FLAGS)
+
+clean:
+	swift package clean
+
+install: build
+	install -d "$(BINARIES_FOLDER)"
+	install "$(EXECUTABLE)" "$(BINARIES_FOLDER)"
+
+
+uninstall:
+	rm -f "$(BINARIES_FOLDER)/dumpling-cli"

--- a/dumpling-cli/Package.swift
+++ b/dumpling-cli/Package.swift
@@ -1,0 +1,27 @@
+// swift-tools-version:5.3
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "dumpling-cli",
+    products: [
+        .executable(name: "dumpling-cli", targets: ["dumpling-cli"])
+    ],
+    dependencies: [
+        .package(
+            url: "https://github.com/apple/swift-argument-parser",
+            .upToNextMinor(from: "0.4.0")
+        ),
+        .package(name: "Dumpling", path: "../")
+    ],
+    targets: [
+        .target(
+            name: "dumpling-cli",
+            dependencies: [
+                .product(name: "ArgumentParser", package: "swift-argument-parser"),
+                "Dumpling"
+            ]
+        )
+    ]
+)

--- a/dumpling-cli/Sources/dumpling-cli/Utils.swift
+++ b/dumpling-cli/Sources/dumpling-cli/Utils.swift
@@ -1,0 +1,14 @@
+//
+//  Utils.swift
+//  
+//
+//  Created by Wojciech Chojnacki on 22/04/2021.
+//
+
+import Foundation
+
+extension FileHandle: TextOutputStream {
+  public func write(_ string: String) {
+    self.write(string.data(using: .utf8)!)
+  }
+}

--- a/dumpling-cli/Sources/dumpling-cli/main.swift
+++ b/dumpling-cli/Sources/dumpling-cli/main.swift
@@ -1,0 +1,58 @@
+//
+//  File.swift
+//  
+//
+//  Created by Wojciech Chojnacki on 22/04/2021.
+//
+
+import Foundation
+import ArgumentParser
+import Dumpling
+
+enum OutputFormat: String, ExpressibleByArgument {
+    case html
+}
+
+struct DumplingCommand: ParsableCommand {
+    static var configuration = CommandConfiguration(
+         commandName: "dumpling-cli",
+         abstract: "Markdown parser"        
+       )
+
+    @Option(name: .shortAndLong, help: "The output format.")
+    var output: OutputFormat = .html
+
+    @Argument(help: "Input markdown file")
+    var filePath: String
+
+    mutating func run() throws {
+
+        let fileURL: URL
+
+        if filePath.hasPrefix("/") {
+            fileURL = URL(fileURLWithPath: filePath, isDirectory: false)
+        } else {
+            let directory = FileManager.default.currentDirectoryPath
+            let directoryURL = URL(fileURLWithPath: directory, isDirectory: true)
+            fileURL = directoryURL.appendingPathComponent(filePath)
+        }
+
+        let string: String
+
+        let data = try Data(contentsOf: fileURL)
+        string = String(decoding: data, as: UTF8.self)
+
+
+        let parser = Markdown()
+        let ast = parser.parse(string)
+
+        switch output {
+        case .html:
+            let result = ast.renderHTML()
+            FileHandle.standardOutput.write(result)
+            FileHandle.standardOutput.write("\n")
+        }
+    }
+}
+
+DumplingCommand.main()


### PR DESCRIPTION
Currently `dumpling-cli` produces only one output format - html.