### PR TITLE
Break reference cycles

### DIFF
--- a/Sources/Dumpling/Markdown/Markdown.swift
+++ b/Sources/Dumpling/Markdown/Markdown.swift
@@ -46,7 +46,11 @@ public final class Markdown {
         exitParser: Parser<Void>,
         preExitCheckParser: Parser<Void>? = nil
     ) -> Parser<[ASTNode]> {
-        return .init("inline") { reader in
+        return .init("inline") { [weak self] reader in
+            guard let self = self else {
+                return nil
+            }
+            
             guard !reader.isEmpty else {
                 return nil
             }

--- a/Sources/Dumpling/Renderer/AttributedString/AttributedStringRenderer.swift
+++ b/Sources/Dumpling/Renderer/AttributedString/AttributedStringRenderer.swift
@@ -19,7 +19,7 @@ public typealias StringAttributesType = [NSAttributedString.Key: Any]
 public class AttributedStringRenderer: Renderer {
     /// Helper type preventing exposing `HTMLRenderer::render(_ nodes: [ASTNode])` in the public interface
     private struct ContentRenderer: AttributedStringContentRenderer {
-        let renderer: AttributedStringRenderer
+        unowned let renderer: AttributedStringRenderer
         func render(_ nodes: [ASTNode], context: AttributedStringRenderer.Context) -> NSAttributedString {
             renderer.render(nodes, context: context)
         }


### PR DESCRIPTION
fixes #8 

I changed two circular references to be `weak`/`unowned` to prevent retain cycles and memory leaks.